### PR TITLE
added virtual when generating Model property

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Common/ModelTemplate.cshtml
@@ -139,7 +139,7 @@ namespace @(Settings.Namespace).@(Model.isCouchbaseModel ? $"{Settings.ModelsNam
             }
            
         @:@(Model.PropertyTypeSelectionStrategy.GetJsonSerializationAttribute(property, Model.isCouchbaseModel))
-        @:public @Model.PropertyTypeSelectionStrategy.GetPropertyTypeName(property) @property.Name { get; @(property.IsReadOnly ? "protected " : "")set; }
+        @:public virtual @Model.PropertyTypeSelectionStrategy.GetPropertyTypeName(property) @property.Name { get; @(property.IsReadOnly ? "protected " : "")set; }
         @EmptyLine
         }
 

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -159,7 +159,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
             {
         @:[Newtonsoft.Json.JsonProperty(PropertyName = "@property.SerializedName")]
             }
-        @:public @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "protected " : "")set; }
+        @:public virtual @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "protected " : "")set; }
         @EmptyLine
         }
 


### PR DESCRIPTION
Modify ModelTemplate to append **virual** when generating Model property. 
This will allow user to override auto-generated non-nullable property if he need to make that property nullable.