### PR TITLE
support broken rule when SMAPI return BadRequest 400

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/AutoRest.CSharp.LoadBalanced.Legacy.csproj
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/AutoRest.CSharp.LoadBalanced.Legacy.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Authors>Agoda, Microsoft</Authors>
@@ -34,6 +34,9 @@
 
   <ItemGroup>
     <None Update="Templates\Rest\Client\ApiBaseTemplate.cshtml">
+      <Generator>RazorGenerator</Generator>
+    </None>
+    <None Update="Templates\Rest\Client\BadRequestExceptionTemplate.cshtml">
       <Generator>RazorGenerator</Generator>
     </None>
     <None Update="Templates\Rest\Client\BrokenRuleTemplate.cshtml">

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/LoadBalancedLegacyCodeGeneratorCs.cs
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/LoadBalancedLegacyCodeGeneratorCs.cs
@@ -97,6 +97,10 @@ namespace AutoRest.CSharp.LoadBalanced.Legacy
             var apiBaseCsPath = "ApiBase.cs";
             await Write(apiBaseTemplate, apiBaseCsPath);
 
+            var badRequestExceptionTemplate = new BadRequestExceptionTemplate();
+            var badRequestPath = "BadRequestException.cs";
+            await Write(badRequestExceptionTemplate, badRequestPath);
+
             // operations
             foreach (var methodGroup in methodGroups)
             {

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -14,6 +14,8 @@ using Agoda.RoundRobin;
 using Agoda.RoundRobin.Constants;
 using Microsoft.Rest.Serialization;
 using Agoda.Http.Client.WinHttp;
+using System.Web;
+using AutoRest.CSharp.LoadBalanced.Json;
 
 @EmptyLine
 namespace @Settings.Namespace
@@ -122,13 +124,20 @@ namespace @Settings.Namespace
 
                 executeResult = await request.ExecuteAsync();
 
-                if (!executeResult.IsOK)
-                {
-                    throw executeResult.GetExeptions();
-                }
-
                 var statusCode = executeResult.Status;
                 var responseContent = executeResult.Results;
+
+                if (!executeResult.IsOK)
+                {
+                    switch (statusCode)
+                    {
+                        case 400:
+                            var brokenRulesDto = JsonConvert.DeserializeObject<ValidationError>(responseContent, DeserializationSettings);
+                            throw new BadRequestException(brokenRulesDto);
+                        default:
+                            throw executeResult.GetExeptions();
+                    }
+                }
 
                 if (statusCode != 200)
                 {

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/BadRequestExceptionTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/BadRequestExceptionTemplate.cshtml
@@ -1,0 +1,14 @@
+﻿@inherits AutoRest.Core.Template<System.Collections.Generic.IEnumerable<AutoRest.CSharp.LoadBalanced.Legacy.Model.MethodCs>>
+using System;
+
+namespace @Settings.Namespace
+{
+	public class BadRequestException : Exception
+	{
+        public ValidationError BrokenRules {get; set;}
+
+        public BadRequestException(ValidationError brokenRules) {
+            BrokenRules = brokenRules;
+        }
+	}
+}

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/BrokenRuleTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/BrokenRuleTemplate.cshtml
@@ -16,5 +16,17 @@ namespace @Settings.Namespace
 		public string Value { get; set; }
 
 		public int ErrorCode { get; set; }
+
+        public int Code { get; set; }
 	}
+
+    public class BrokenRules
+    {
+        public BrokenRule[] ValidationErrors { get; set; }
+    }
+
+    public class ValidationError
+    {
+        public BrokenRules ValidationErrors { get; set; }
+    }
 }

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/MethodTemplate.cshtml
@@ -94,6 +94,10 @@ public async @(Model.OperationResponseReturnTypeStringForMethodName) @(Model.Nam
         response.Result = result;
     }
     }
+    catch(BadRequestException ex)
+    {
+        response.BrokenRules = ex.BrokenRules.ValidationErrors.ValidationErrors.ToList();
+    }
     catch (Exception ex)
     {
         response.BrokenRules.Add(new BrokenRule() { Description = ex.Message, Value = ex.Message });


### PR DESCRIPTION
Currently, auto-rest client always throws _object reference not set to an instance of an object_ when SMAPI returns BadRequest code=400. Expected result is it should return list of broken rules when it fail in server-side validation.

To support broken rule, I create BadRequestException that has list of broken rule as property. User can use code property in  broken rules to map to CMS Id to support translation  