### PR TITLE
added logic to parse datetime from SMAPI

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Json/DateTimeStringConverter.cs
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Json/DateTimeStringConverter.cs
@@ -77,7 +77,12 @@ namespace AutoRest.CSharp.LoadBalanced.Json
             {
                 return defaultDateTime;
             }
-            
+
+            if (DateTime.TryParseExact(dateTimeValue, "M/d/yyyy hh:mm:s tt", CultureInfo.InvariantCulture, DateTimeStyles.None, out defaultDateTime))
+            {
+                return defaultDateTime;
+            }
+
             if (DateTime.TryParseExact(dateTimeValue, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out defaultDateTime))
             {
                 return defaultDateTime;


### PR DESCRIPTION
**Problem**
currently, DateTimeStringConverter cannot parse datetime string from SMAPI in format **M/d/yyyy hh:mm:s tt** e.g. "1/23/2018 11:59:0 PM" so all DateTime properties in autorest model will get default value Date = 1/1/0001 12:00:00 AM instead.

**Expected Result**
DateTimeStringConverter should able to parse string "1/23/2018 11:59:0 PM"