### PR TITLE
Remove double UrlEncode for query parameters

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -337,16 +337,19 @@ namespace @Settings.Namespace
 
                 var uriBuilder = new UriBuilder(null, null, -1, path);
 
-                // Append the remaining parameters as query string if this is a GET request.
-                if (verb == Verbs.GET)
+                // Append the remaining parameters as query string.
+                var uriBuilder = new UriBuilder(null, null, -1, path)
                 {
-                    uriBuilder.Query = string.Join("&", query.Select(parameter =>
-                    {
-                        var name = HttpUtility.UrlEncode(parameter.Key);
-                        var value = HttpUtility.UrlEncode(parameter.Value);
-                        return $"{name}={value}";
-                    }));
-                }
+                    Query = string.Join(
+                        "&",
+                        query.Select(
+                            parameter =>
+                            {
+                                var name = HttpUtility.UrlEncode(parameter.Key);
+                                var value = parameter.Value;
+                                return $"{name}={value}";
+                            }))
+                };
 
                 return uriBuilder.ToString();
             }

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -334,22 +334,18 @@ namespace @Settings.Namespace
                         query[parameterName] = urlValue;
                     }
                 }
-
                 var uriBuilder = new UriBuilder(null, null, -1, path);
 
-                // Append the remaining parameters as query string.
-                var uriBuilder = new UriBuilder(null, null, -1, path)
+                // Append the remaining parameters as query string if this is a GET request.
+                if (verb == Verbs.GET)
                 {
-                    Query = string.Join(
-                        "&",
-                        query.Select(
-                            parameter =>
-                            {
-                                var name = HttpUtility.UrlEncode(parameter.Key);
-                                var value = parameter.Value;
-                                return $"{name}={value}";
-                            }))
-                };
+                    uriBuilder.Query = string.Join("&", query.Select(parameter =>
+                    {
+                        var name = HttpUtility.UrlEncode(parameter.Key);
+                        var value = parameter.Value;
+                        return $"{name}={value}";
+                    }));
+                }
 
                 return uriBuilder.ToString();
             }


### PR DESCRIPTION
- UrlEncode logic should only be applied once or otherwise the data will end up unusable. 
