### PR TITLE
Update HttpRequestCommand requestContent initialize

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -235,7 +235,6 @@ namespace @Settings.Namespace
                 _url = new Lazy<string>(() => GetUrl(restUrl, queryParameters));
                 _serializationSettings = serializationSettings;
                 _customHeaders = customHeaders;
-                var requestContent = 
                 _requestContent = new Lazy<byte[]>(() => GetRequestContent(httpVerb, body));
                 _manualCalcUris = manualCalcUris;
                 _overrideHostHeader = overrideHostHeader;

--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -236,7 +236,7 @@ namespace @Settings.Namespace
                 _serializationSettings = serializationSettings;
                 _customHeaders = customHeaders;
                 _requestContent = new Lazy<byte[]>(() => body == null
-                                ? new byte[0]
+                                ? null
                                 : Encoding.UTF8.GetBytes(SafeJsonConvert.SerializeObject(body,
                                     _serializationSettings)));
                 _manualCalcUris = manualCalcUris;
@@ -251,7 +251,7 @@ namespace @Settings.Namespace
                 var result = await httpClient.ExecuteAsync(
                     _verb,
                     _url.Value,
-                    _requestContent.Value,
+                    _requestContent?.Value,
                     false,
                     new ErrorList(),
                     true,

--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -235,10 +235,8 @@ namespace @Settings.Namespace
                 _url = new Lazy<string>(() => GetUrl(restUrl, queryParameters));
                 _serializationSettings = serializationSettings;
                 _customHeaders = customHeaders;
-                _requestContent = new Lazy<byte[]>(() => body == null
-                                ? null
-                                : Encoding.UTF8.GetBytes(SafeJsonConvert.SerializeObject(body,
-                                    _serializationSettings)));
+                var requestContent = 
+                _requestContent = new Lazy<byte[]>(() => GetRequestContent(httpVerb, body));
                 _manualCalcUris = manualCalcUris;
                 _overrideHostHeader = overrideHostHeader;
             }
@@ -258,6 +256,13 @@ namespace @Settings.Namespace
                     _customHeaders);
 
                 return result;
+            }
+@EmptyLine
+            protected byte[] GetRequestContent(Verbs verb, object body)
+            {
+                if (body != null)
+                    return Encoding.UTF8.GetBytes(SafeJsonConvert.SerializeObject(body, _serializationSettings));
+                return verb == Verbs.GET ? null : new byte[0];
             }
 @EmptyLine
             protected string GetUrl(string restUrl, Dictionary<string, object> queryParameters)


### PR DESCRIPTION
Add logic to set requestContent to null in case of GET request. Inside Agoda.RoundRobin [HttpClient](https://github.agodadev.io/IT-Platform/Agoda.RoundRobin/blob/master/Agoda.RoundRobin/HttpClient.cs#L322) when using GET request, WebRequest.GetRequestStream shouldn't be called and will cause exceptions