### PR TITLE
[HOSTW-914] Add manual Calc Uris and  override Host Header within legacy template

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -261,7 +261,7 @@ namespace @Settings.Namespace
                 string restUrl,
                 Dictionary<string, object> queryParameters,
                 Dictionary<string, string> customHeaders = null,
-                object body = null
+                object body = null,
                 bool manualCalcUris = false,
                 bool overrideHostHeader = false)
             {

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -45,6 +45,10 @@ namespace @Settings.Namespace
         TimeSpan? timeout { get; set; }
 
         int retryCount { get; set; }
+	    
+        bool? manualCalcUris { get; set; }
+
+        bool? overrideHostHeader { get; set; }
 
         JsonSerializerSettings serializationSettings { get; set; }
 
@@ -58,6 +62,8 @@ namespace @Settings.Namespace
         public List<ServerSettings> settings { get; set; }
         public TimeSpan? timeout { get; set; }
         public int retryCount { get; set; }
+        public bool? manualCalcUris { get; set; }
+        public bool? overrideHostHeader { get; set; }
         public JsonSerializerSettings serializationSettings { get; set; }
         public JsonSerializerSettings deserializationSettings { get; set; }
     }
@@ -81,6 +87,8 @@ namespace @Settings.Namespace
             _timeout = apiBaseConfig.timeout ?? TimeSpan.FromMilliseconds(1000);
             _settings = apiBaseConfig.settings;
             _retryCount = apiBaseConfig.retryCount;
+            _manualCalcUris = apiBaseConfig.manualCalcUris ?? false;
+            _overrideHostHeader = apiBaseConfig.overrideHostHeader ?? false;
             _serializationSettings = apiBaseConfig.serializationSettings;
             _deserializationSettings = apiBaseConfig.deserializationSettings;
         }
@@ -150,7 +158,9 @@ namespace @Settings.Namespace
                             parameters.RestUrl,
                             parameters.QueryParameters,
                             parameters.CustomHeaders,
-                            parameters.Body);
+                            parameters.Body,
+                            _manualCalcUris,
+                            _overrideHostHeader);
 
                 executeResult = await request.ExecuteAsync();
 
@@ -238,6 +248,8 @@ namespace @Settings.Namespace
             private readonly List<ServerSettings> _settings;
             private readonly int _retryCount;
             private readonly TimeSpan _timeout;
+            private readonly bool _manualCalcUris;
+            private readonly bool _overrideHostHeader;
 
             internal HttpRequestCommand(
                 string name,
@@ -249,7 +261,9 @@ namespace @Settings.Namespace
                 string restUrl,
                 Dictionary<string, object> queryParameters,
                 Dictionary<string, string> customHeaders = null,
-                object body = null)
+                object body = null
+                bool manualCalcUris = false,
+                bool overrideHostHeader = false)
             {
                 if (customHeaders != null && customHeaders.ContainsKey("Content-Type"))
                 {
@@ -277,7 +291,7 @@ namespace @Settings.Namespace
             {
                 var timeout = (int)_timeout.TotalMilliseconds;
                 var requestContent = (_requestContent.Value.Length > 0) ? _requestContent.Value : null;
-                var httpClient = new HttpClient(_name, _settings, JsonContentType, timeout, _retryCount, "");
+                var httpClient = new HttpClient(_name, _settings, JsonContentType, timeout, _retryCount, "", manualCalcUris: _manualCalcUris, overrideHostHeader: _overrideHostHeader);
                 
                 // this will need to be called async as part of a client update. This because of
                 // unexpected deadlocks when using the current implementation.

--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -76,6 +76,8 @@ namespace @Settings.Namespace
         private JsonSerializerSettings _deserializationSettings;
         private readonly TimeSpan _timeout;
         private readonly int _retryCount;
+        private readonly bool _manualCalcUris;
+        private readonly bool _overrideHostHeader;
         private readonly string _name;
         private event EventHandler<MetricSendEventArgs> _metricSendEvent;
         private event EventHandler<ErrorEventArgs> _errorEvent;
@@ -265,6 +267,8 @@ namespace @Settings.Namespace
                 bool manualCalcUris = false,
                 bool overrideHostHeader = false)
             {
+                _manualCalcUris = manualCalcUris;
+                _overrideHostHeader = overrideHostHeader;
                 if (customHeaders != null && customHeaders.ContainsKey("Content-Type"))
                 {
                     _contentType = customHeaders["Content-Type"];


### PR DESCRIPTION
By default, RoundRobin resolves DNS address into IP address before making a request. To send a request directly using DNS, use overrideHostHeader=true in the configuration.