### PR TITLE
[HOSTW-ERD][Legacy] Exception fallback when content is missing

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -173,6 +173,11 @@ namespace @Settings.Namespace
 
                 if (!executeResult.IsOK)
                 {
+                    if (string.IsNullOrEmpty(responseContent))
+                    {
+                        throw executeResult.GetExeptions();
+                    }
+			
                     switch (statusCode)
                     {
                         case 400:


### PR DESCRIPTION
Can only return Broken Rules when content is available.