### PR TITLE
Add payload in error message

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -35,6 +35,7 @@ namespace @Settings.Namespace
         public Exception Exception { get; set; }
         public string RouteName { get; set; }
         public ExecuteResult ExecuteResult { get; set; }
+        public object Payload { get; set; }
     }
 @EmptyLine
 
@@ -209,7 +210,7 @@ namespace @Settings.Namespace
             }
             catch (Exception ex)
             {
-                _errorEvent?.Invoke(this, new ErrorEventArgs { Exception = ex, RouteName = metricName, ExecuteResult = executeResult });
+                _errorEvent?.Invoke(this, new ErrorEventArgs { Exception = ex, RouteName = metricName, ExecuteResult = executeResult, Payload = parameters});
                 throw;
             }
             finally


### PR DESCRIPTION
Adding the payload in the error message will make troubleshooting and debugging a lot easier.