### PR TITLE
[HOSTW-1435] Ignore ssl policy errors (B)

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -267,9 +267,8 @@ namespace @Settings.Namespace
 @EmptyLine
             private bool CertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
             {
-                // make sure we only ignore our request
-                var request = sender as WebRequest;
-                return request?.RequestUri.ToString().EndsWith(_url.Value) == true;
+                // this is intentionally set to true
+                return true;
             }
 @EmptyLine        
             internal async Task<ExecuteResult> ExecuteAsync()


### PR DESCRIPTION
Implementing this within the client until ARR v2 is able to set this per request,

Removed request context check because it was causing unexpected behavior.