### PR TITLE
Support HttpData injection

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits AutoRest.Core.Template<AutoRest.CSharp.LoadBalanced.Model.CodeModelCs>
+@inherits AutoRest.Core.Template<AutoRest.CSharp.LoadBalanced.Model.CodeModelCs>
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -36,6 +36,11 @@ namespace @Settings.Namespace
         public Dictionary<string, object> Tags { get; set; }
     }
 @EmptyLine
+    public class HttpData
+    {
+        public Dictionary<string, string> Headers {get; set;} 
+    }
+@EmptyLine
     public interface IApiBaseConfig
     {
         string name { get; set; }
@@ -50,6 +55,7 @@ namespace @Settings.Namespace
         bool? ignoreSslPolicyErrors { get; set; }
         EventHandler<MetricSendEventArgs> metricEvent { get; set; }
         EventHandler<ErrorEventArgs> errorEvent { get; set; }
+        Func<HttpData> httpData { get; set; }
     }
 
     public class ApiBaseConfig : IApiBaseConfig
@@ -66,6 +72,7 @@ namespace @Settings.Namespace
         public bool? ignoreSslPolicyErrors { get; set; }
         public EventHandler<MetricSendEventArgs> metricEvent { get; set; }
         public EventHandler<ErrorEventArgs> errorEvent { get; set; }
+        public Func<HttpData> httpData { get; set; }
     }
 
     public abstract class ApiBase
@@ -82,6 +89,7 @@ namespace @Settings.Namespace
         private event EventHandler<MetricSendEventArgs> _metricSendEvent;
         private event EventHandler<ErrorEventArgs> _errorEvent;
         private readonly bool _ignoreSslPolicyErrors;
+        private Func<HttpData> _httpData;
 @EmptyLine
         protected ApiBase(IApiBaseConfig apiBaseConfig)
         {
@@ -95,11 +103,13 @@ namespace @Settings.Namespace
             _deserializationSettings = apiBaseConfig.deserializationSettings;
             _customHeaders = apiBaseConfig.customHeaders;
             _ignoreSslPolicyErrors = apiBaseConfig.ignoreSslPolicyErrors ?? false;
-
+@EmptyLine
             if (apiBaseConfig.metricEvent != null)
                 _metricSendEvent += apiBaseConfig.metricEvent;
             if (apiBaseConfig.errorEvent != null)
                 _errorEvent += apiBaseConfig.errorEvent;
+@EmptyLine
+            _httpData = apiBaseConfig.httpData;
         }
 @EmptyLine
 
@@ -144,6 +154,13 @@ namespace @Settings.Namespace
             ExecuteResult executeResult = null;
             try
             {
+                // restructure if we need more in the future
+                var httpDataHeaders = _httpData?.Invoke()?.Headers;
+                if (httpDataHeaders != null && httpDataHeaders.Any())
+                {
+                    parameters.CustomHeaders.Concat(httpDataHeaders);
+                }
+
                 var request = new HttpRequestCommand(
                             _name,
                             _settings,

--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Agoda.RoundRobin;
 using Agoda.RoundRobin.Constants;
 using Microsoft.Rest.Serialization;
+using System.Linq;
 @EmptyLine
 namespace @Settings.Namespace
 {

--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -159,7 +159,11 @@ namespace @Settings.Namespace
                 var httpDataHeaders = _httpData?.Invoke()?.Headers;
                 if (httpDataHeaders != null && httpDataHeaders.Any())
                 {
-                    parameters.CustomHeaders.Concat(httpDataHeaders);
+                    if (parameters.CustomHeaders == null)
+                        parameters.CustomHeaders = new Dictionary<string, string>();
+
+                    parameters.CustomHeaders = parameters.CustomHeaders
+                        .Concat(httpDataHeaders).ToDictionary(x=>x.Key,x=>x.Value);;
                 }
 
                 var request = new HttpRequestCommand(


### PR DESCRIPTION
It should not be required to explicitly provide common data like user tokens. There should be an option to inject this data on a per request basis and automatically added to existing request data.