### PR TITLE
add response message when content is not null or whitespace

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -185,6 +185,11 @@ namespace @Settings.Namespace
 
                 if (!executeResult.IsSuccessStatus)
                 {
+                    if(!string.IsNullOrWhiteSpace(responseContent))
+                    {
+                        throw new Exception(responseContent);
+                    }
+
                     throw executeResult.GetExeptions();
                 }
 

--- a/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp.LoadBalanced/Templates/Rest/Client/ApiBaseTemplate.cshtml
@@ -183,6 +183,7 @@ namespace @Settings.Namespace
 
                 executeResult = await request.ExecuteAsync();
 
+                var responseContent = executeResult.Results;
                 if (!executeResult.IsSuccessStatus)
                 {
                     if(!string.IsNullOrWhiteSpace(responseContent))
@@ -194,7 +195,7 @@ namespace @Settings.Namespace
                 }
 
                 var statusCode = executeResult.Status;
-                var responseContent = executeResult.Results;
+                
 
                 try
                 {


### PR DESCRIPTION
When the HTTP response is not OK (200), response message or body should be included in the exception.