### PR TITLE
exclude rackRate as from moneyType

### DIFF
--- a/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Strategies/WrappedPropertyTypeSelectionStrategy.cs
+++ b/src/generator/AutoRest.CSharp.LoadBalanced.Legacy/Strategies/WrappedPropertyTypeSelectionStrategy.cs
@@ -8,11 +8,12 @@ namespace AutoRest.CSharp.LoadBalanced.Legacy.Strategies
 {
     public class WrappedPropertyTypeSelectionStrategy : PropertyTypeSelectionStrategy
     {
-        private static string[] _datePostfixes = new[] {"When", "Time", "Date"};
-        private static string[] _guidPostfixes = new[] { "By", "UserId", "Token" };
-        private static string[] _moneyPostfixes = new[] { "Cost", "Rate", "Amount", "Price", "Discount", "Fee", "Percent" };
-        private static string[] _booleanSuffixes = new[] {"allotmentAutoToPup", "Flag" };
-        private static string[] _booleanPrefixes = new[] {"is"};
+        private static string[] _datePostfixes = {"When", "Time", "Date"};
+        private static string[] _guidPostfixes = { "By", "UserId", "Token" };
+        private static string[] _moneyPostfixes = { "Cost", "Rate", "Amount", "Price", "Discount", "Fee", "Percent" };
+        private static string[] _booleanSuffixes = {"allotmentAutoToPup", "Flag" };
+        private static string[] _booleanPrefixes = {"is"};
+        private static string[] _notMoney = { "rackrate" };
         public override bool IsDateTime(Property property)
         {
             if(IsDateText(property))
@@ -33,7 +34,9 @@ namespace AutoRest.CSharp.LoadBalanced.Legacy.Strategies
         public override bool IsMoney(Property property)
         {
             if (property.ModelType.Name == "string" && _moneyPostfixes.Any(
-                p => property.Name.RawValue.ToUpper().EndsWith(p.ToUpper())))
+                p => property.Name.RawValue.ToUpper().EndsWith(p.ToUpper()))
+                && !_notMoney.Contains(property.Name.RawValue.ToLower())
+                )
             {
                 return true;
             }


### PR DESCRIPTION
Fix for the rackRate Issue. 
As the smapi has changed the rackRate to string, doing the same in the client.

Campared the old and new generate models to see that no other model was affected, the result of the comparison
```
diff -r Generated_new/Models/Couchbase/PropertyRoomType.cs Generated_old/Models/Couchbase/PropertyRoomType.cs
34c34
<         public PropertyRoomType(int hotelId, int hotelRoomTypeId, string hotelRoomTypeName, bool hotelRoomTypeYcsFlag, int noOfPhoto, int noOfRooms, int allotmentAlertLevel, int maxOccupancy, int maxExtraBed, int maxChildrenInRoom, int maxInfantCots, bool isBreakfastIncluded, decimal minimumRate, decimal maximumRate, string rackRate, int masterRoomTypeId, int productOfferTypeId, double sizeOfRoom, int noOfBedrooms, int noOfBathrooms, int noOfRoomFacilities, int maxOptionId, decimal standardRate, string defaultHotelRateCategoryName, int viewId, string roomDescription, string captionText, string captionId, List<BedConfiguration> bedConfiguration, Requestor requestor, string externalRoomTypeCode, int recStatus, int sort)
---
>         public PropertyRoomType(int hotelId, int hotelRoomTypeId, string hotelRoomTypeName, bool hotelRoomTypeYcsFlag, int noOfPhoto, int noOfRooms, int allotmentAlertLevel, int maxOccupancy, int maxExtraBed, int maxChildrenInRoom, int maxInfantCots, bool isBreakfastIncluded, decimal minimumRate, decimal maximumRate, decimal rackRate, int masterRoomTypeId, int productOfferTypeId, double sizeOfRoom, int noOfBedrooms, int noOfBathrooms, int noOfRoomFacilities, int maxOptionId, decimal standardRate, string defaultHotelRateCategoryName, int viewId, string roomDescription, string captionText, string captionId, List<BedConfiguration> bedConfiguration, Requestor requestor, string externalRoomTypeCode, int recStatus, int sort)
114c114
<         public virtual string RackRate { get; set; }
---
>         public virtual decimal RackRate { get; set; }
diff -r Generated_new/Models/PropertyRoomType.cs Generated_old/Models/PropertyRoomType.cs
33c33
<         public PropertyRoomType(int hotelId, int hotelRoomTypeId, string hotelRoomTypeName, bool hotelRoomTypeYcsFlag, int noOfPhoto, int noOfRooms, int allotmentAlertLevel, int maxOccupancy, int maxExtraBed, int maxChildrenInRoom, int maxInfantCots, bool isBreakfastIncluded, decimal minimumRate, decimal maximumRate, string rackRate, int masterRoomTypeId, int productOfferTypeId, double sizeOfRoom, int noOfBedrooms, int noOfBathrooms, int noOfRoomFacilities, int maxOptionId, decimal standardRate, string defaultHotelRateCategoryName, int viewId, string roomDescription, string captionText, string captionId, List<BedConfiguration> bedConfiguration, Requestor requestor, string externalRoomTypeCode, int recStatus, int sort)
---
>         public PropertyRoomType(int hotelId, int hotelRoomTypeId, string hotelRoomTypeName, bool hotelRoomTypeYcsFlag, int noOfPhoto, int noOfRooms, int allotmentAlertLevel, int maxOccupancy, int maxExtraBed, int maxChildrenInRoom, int maxInfantCots, bool isBreakfastIncluded, decimal minimumRate, decimal maximumRate, decimal rackRate, int masterRoomTypeId, int productOfferTypeId, double sizeOfRoom, int noOfBedrooms, int noOfBathrooms, int noOfRoomFacilities, int maxOptionId, decimal standardRate, string defaultHotelRateCategoryName, int viewId, string roomDescription, string captionText, string captionId, List<BedConfiguration> bedConfiguration, Requestor requestor, string externalRoomTypeCode, int recStatus, int sort)
112,113c112,113
<         [JsonProperty(PropertyName = "rackRate", NullValueHandling=NullValueHandling.Ignore)]
<         public virtual string RackRate { get; set; }
---
>         [JsonProperty(PropertyName = "rackRate", NullValueHandling=NullValueHandling.Ignore), JsonConverter(typeof(MoneyConverter))]
>         public virtual decimal RackRate { get; set; }
```